### PR TITLE
Academic Word Lists

### DIFF
--- a/AcademicWordList/list-1.md
+++ b/AcademicWordList/list-1.md
@@ -1,0 +1,75 @@
+---
+langr: xxxx
+langr-audio: null
+langr-origin: list-1
+langr-pos: "1"
+---
+^^^article
+
+sector
+ available
+ financial
+ process
+ individual
+ specific
+ principle
+ estimate
+ variables
+ method
+ data
+ research
+ contract
+ environment
+ export
+ source
+ assessment
+ policy
+ identified
+ create
+ derived
+ factors
+ procedure
+ definition
+ assume
+ theory
+ benefit
+ evidence
+ established
+ authority
+ major
+ issues
+ labour
+ occur
+ economic
+ involved
+ percent
+ interpretation
+ consistent
+ income
+ structure
+ legal
+ concept
+ formula
+ section
+ required
+ constitutional
+ analysis
+ distribution
+ function
+ area
+ approach
+ role
+ legislation
+ indicate
+ response
+ period
+ context
+ significant
+ similar
+
+^^^words
+
++ **financial** : adj. 财政的，金融的；<澳新，非正式>有钱的；<澳新>（俱乐部或社团成员）已缴费的
+  n. （组织或个人的）财务状况；金融公司股票
+
+^^^notes

--- a/AcademicWordList/list-10.md
+++ b/AcademicWordList/list-10.md
@@ -1,0 +1,45 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-10
+---
+
+^^^article
+
+whereby 
+ inclination 
+ encountered 
+ convinced 
+ assembly 
+ albeit 
+ enormous 
+ reluctant 
+ posed 
+ persistent 
+ undergo 
+ notwithstanding 
+ straightforward 
+ panel 
+ odd 
+ intrinsic 
+ compiled 
+ adjacent 
+ integrity 
+ forthcoming 
+ conceived 
+ ongoing 
+ so-called 
+ likewise 
+ nonetheless 
+ levy 
+ invoked 
+ colleagues 
+ depression 
+ collapse 
+
+
+^^^words
+
+
+
+^^^notes

--- a/AcademicWordList/list-2.md
+++ b/AcademicWordList/list-2.md
@@ -1,0 +1,71 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-2
+---
+^^^article
+
+community
+ resident
+ range
+ construction
+ strategies
+ elements
+ previous
+ conclusion
+ security
+ aspects
+ acquisition
+ features
+ text
+ commission
+ regulations
+ computer
+ items
+ consumer
+ achieve
+ final
+ positive
+ evaluation
+ assistance
+ normal
+ relevant
+ distinction
+ region
+ traditional
+ impact
+ consequences
+ chapter
+ equation
+ appropriate
+ resources
+ participation
+ survey
+ potential
+ cultural
+ transfer
+ select
+ credit
+ affect
+ categories
+ perceived
+ sought
+ focus
+ purchase
+ injury
+ site
+ journal
+ primary
+ complex
+ institute
+ investment
+ administration
+ maintenance
+ design
+ obtained
+ restricted
+ conduct
+
+^^^words
+
+^^^notes

--- a/AcademicWordList/list-3.md
+++ b/AcademicWordList/list-3.md
@@ -1,0 +1,71 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-3
+---
+^^^article
+
+comments
+ convention
+ published
+ framework
+ implies
+ negative
+ dominant
+ illustrated
+ outcomes
+ constant
+ shift
+ deduction
+ ensure
+ specified
+ justification
+ funds
+ reliance
+ physical
+ partnership
+ location
+ link
+ coordination
+ alternative
+ initial
+ validity
+ task
+ techniques
+ excluded
+ consent
+ proportion
+ demonstrate
+ reaction
+ criteria
+ minorities
+ technology
+ philosophy
+ removed
+ sex
+ compensation
+ sequence
+ corresponding
+ maximum
+ circumstances
+ instance
+ considerable
+ sufficient
+ corporate
+ interaction
+ contribution
+ immigration
+ component
+ constraints
+ technical
+ emphasis
+ scheme
+ layer
+ volume
+ document
+ registered
+ core
+
+^^^words
+
+^^^notes

--- a/AcademicWordList/list-4.md
+++ b/AcademicWordList/list-4.md
@@ -1,0 +1,74 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-4
+---
+
+^^^article
+
+overall 
+ emerged 
+ regime 
+ implementation 
+ project 
+ hence 
+ occupational 
+ internal 
+ goals 
+ retained 
+ sum 
+ integration 
+ mechanism 
+ parallel 
+ imposed 
+ despite 
+ job 
+ parameters 
+ approximate 
+ label 
+ concentration 
+ principal 
+ series 
+ predicted 
+ summary 
+ attitudes 
+ undertaken 
+ cycle 
+ communication 
+ ethnic 
+ hypothesis 
+ professional 
+ status 
+ conference 
+ attributed 
+ annual 
+ obvious 
+ error 
+ implications 
+ apparent 
+ commitment 
+ subsequent 
+ debate 
+ dimensions 
+ promote 
+ statistics 
+ option 
+ domestic 
+ output 
+ access 
+ code 
+ investigation 
+ phase 
+ prior 
+ granted 
+ stress 
+ civil 
+ contrast 
+ resolution 
+ adequate
+
+^^^words
+
+
+
+^^^notes

--- a/AcademicWordList/list-5.md
+++ b/AcademicWordList/list-5.md
@@ -1,0 +1,75 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-5
+---
+
+^^^article
+
+alter 
+ stability 
+ energy 
+ aware 
+ licence 
+ enforcement 
+ draft 
+ styles 
+ precise 
+ medical 
+ pursue 
+ symbolic 
+ marginal 
+ capacity 
+ generation 
+ exposure 
+ decline 
+ academic 
+ modified 
+ external 
+ psychology 
+ fundamental 
+ adjustment 
+ ratio 
+ whereas 
+ enable 
+ version 
+ perspective 
+ contact 
+ network 
+ facilitate 
+ welfare 
+ transition 
+ amendment 
+ logic 
+ rejected 
+ expansion 
+ clause 
+ prime 
+ target 
+ objective 
+ sustainable 
+ equivalent 
+ liberal 
+ notion 
+ substitution 
+ generated 
+ trend 
+ revenue 
+ compounds 
+ evolution 
+ conflict 
+ image 
+ discretion 
+ entities 
+ orientation 
+ consultation 
+ mental 
+ monitoring 
+ challenge 
+
+
+^^^words
+
+
+
+^^^notes

--- a/AcademicWordList/list-6.md
+++ b/AcademicWordList/list-6.md
@@ -1,0 +1,75 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-6
+---
+
+^^^article
+
+intelligence 
+ transformation 
+ presumption 
+ acknowledged 
+ utility 
+ furthermore 
+ accurate 
+ diversity 
+ attached 
+ recovery 
+ assigned 
+ tapes 
+ motivation 
+ bond 
+ edition 
+ nevertheless 
+ transport 
+ cited 
+ fees 
+ scope 
+ enhanced 
+ incorporated 
+ instructions 
+ subsidiary 
+ input 
+ abstract 
+ ministry 
+ capable 
+ expert 
+ preceding 
+ display 
+ incentive 
+ inhibition 
+ trace 
+ ignored 
+ incidence 
+ estate 
+ cooperative 
+ revealed 
+ index 
+ lecture 
+ discrimination 
+ overseas 
+ explicit 
+ aggregate 
+ gender 
+ underlying 
+ brief 
+ domain 
+ rational 
+ minimum 
+ interval 
+ neutral 
+ migration 
+ flexibility 
+ federal 
+ author 
+ initiatives 
+ allocation 
+ exceed 
+
+
+^^^words
+
+
+
+^^^notes

--- a/AcademicWordList/list-7.md
+++ b/AcademicWordList/list-7.md
@@ -1,0 +1,75 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-7
+---
+
+^^^article
+
+intervention 
+ confirmed 
+ definite 
+ classical 
+ chemical 
+ voluntary 
+ release 
+ visible 
+ finite 
+ publication 
+ channel 
+ file 
+ thesis 
+ equipment 
+ disposal 
+ solely 
+ deny 
+ identical 
+ submitted 
+ grade 
+ phenomenon 
+ paradigm 
+ ultimately 
+ extract 
+ survive 
+ converted 
+ transmission 
+ global 
+ inferred 
+ guarantee 
+ advocate 
+ dynamic 
+ simulation 
+ topic 
+ insert 
+ reverse 
+ decades 
+ comprise 
+ hierarchical 
+ unique 
+ comprehensive 
+ couple 
+ mode 
+ differentiation 
+ eliminate 
+ priority 
+ empirical 
+ ideology 
+ somewhat 
+ aid 
+ foundation 
+ adults 
+ adaptation 
+ quotation 
+ contrary 
+ media 
+ successive 
+ innovation 
+ prohibited 
+ isolated 
+
+
+^^^words
+
+
+
+^^^notes

--- a/AcademicWordList/list-8.md
+++ b/AcademicWordList/list-8.md
@@ -1,0 +1,75 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-8
+---
+
+^^^article
+
+highlighted 
+ eventually 
+ inspection 
+ termination 
+ displacement 
+ arbitrary 
+ reinforced 
+ denote 
+ offset 
+ exploitation 
+ detected 
+ abandon 
+ random 
+ revision 
+ virtually 
+ uniform 
+ predominantly 
+ thereby 
+ implicit 
+ tension 
+ ambiguous 
+ vehicle 
+ clarity 
+ conformity 
+ contemporary 
+ automatically 
+ accumulation 
+ appendix 
+ widespread 
+ infrastructure 
+ deviation 
+ fluctuations 
+ restore 
+ guidelines 
+ commodity 
+ minimises 
+ practitioners 
+ radical 
+ plus 
+ visual 
+ chart 
+ appreciation 
+ prospect 
+ dramatic 
+ contradiction 
+ currency 
+ inevitably 
+ complement 
+ accompany 
+ paragraph 
+ induced 
+ schedule 
+ intensity 
+ crucial 
+ via 
+ exhibit 
+ bias 
+ manipulation 
+ theme 
+ nuclear 
+
+
+^^^words
+
+
+
+^^^notes

--- a/AcademicWordList/list-9.md
+++ b/AcademicWordList/list-9.md
@@ -1,0 +1,75 @@
+---
+langr: xxxx
+langr-audio: 
+langr-origin: list-9
+---
+
+^^^article
+
+bulk 
+ behalf 
+ unified 
+ commenced 
+ erosion 
+ anticipated 
+ minimal 
+ ceases 
+ vision 
+ mutual 
+ norms 
+ intermediate 
+ manual 
+ supplementary 
+ incompatible 
+ concurrent 
+ ethical 
+ preliminary 
+ integral 
+ conversely 
+ relaxed 
+ confined 
+ accommodation 
+ temporary 
+ distorted 
+ passive 
+ subordinate 
+ analogous 
+ military 
+ scenario 
+ revolution 
+ diminished 
+ coherence 
+ suspended 
+ mature 
+ assurance 
+ rigid 
+ controversy 
+ sphere 
+ mediation 
+ format 
+ trigger 
+ qualitative 
+ portion 
+ medium 
+ coincide 
+ violation 
+ device 
+ insights 
+ refine 
+ devoted 
+ team 
+ overlap 
+ attained 
+ restraints 
+ inherent 
+ route 
+ protocol 
+ founded 
+ duration 
+
+
+^^^words
+
+
+
+^^^notes


### PR DESCRIPTION
The Academic Word List (AWL) was developed by Averil Coxhead at the School of Linguistics and Applied Language Studies at Victoria University of Wellington, New Zealand. The list contains 570 word families which were selected because they appear with great frequency in a broad range of academic texts. The list does not include words that are in the most frequent 2000 words of English (the General Service List), thus making it specific to academic contexts. The AWL was primarily made so that it could be used by teachers as part of a programme preparing learners for tertiary level study or used by students working alone to learn the words most needed to study at colleges and universities.
The 570 words are divided into 10 Groups. The Groups are ordered such that the words in the first Group are the most frequent words and those in the last Group are the least frequent.